### PR TITLE
Adds stricter error handling

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.0.2
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/autodocs.sh
+++ b/autodocs.sh
@@ -41,7 +41,7 @@ do
         else
 
         # validate that the source terraform is valid before proceeding
-        terraform-docs.sh markdown "${dir}" 1>&2 || exit 1
+        terraform-docs.sh markdown "${dir}" > /dev/null 2>&1 || exit 1
 
             # generate the tf documentation
             if [[ -n "$GENERATE" ]]; then

--- a/autodocs.sh
+++ b/autodocs.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -e
+set -u
+
 LINT=
 GENERATE=
 
@@ -36,6 +39,9 @@ do
         if ! test -f "$source_doc"; then 
             echo "ERROR: $source_doc is missing" 1>&2; exit 1
         else
+
+        # validate that the source terraform is valid before proceeding
+        terraform-docs.sh markdown "${dir}" 1>&2 || exit 1
 
             # generate the tf documentation
             if [[ -n "$GENERATE" ]]; then

--- a/terraform-docs.sh
+++ b/terraform-docs.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -u
+
 # https://stackoverflow.com/questions/59895/get-the-source-directory-of-a-bash-script-from-within-the-script-itself/246128#246128
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 


### PR DESCRIPTION
- autodocs.sh: test that terraform-docs.sh runs without error before running it in a subshell
- autodocs.sh: sets bash -e and -u options
- terraform-docs.sh: sets bash -e and -u options